### PR TITLE
Add vitest tests and configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^19.0.0",
@@ -25,6 +26,8 @@
     "globals": "^15.15.0",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.24.1",
-    "vite": "^6.2.0"
+    "vite": "^6.2.0",
+    "vitest": "^1.6.0",
+    "@testing-library/react": "^14.2.1"
   }
 }

--- a/src/context/ColorContext.test.tsx
+++ b/src/context/ColorContext.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { describe, it, expect } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { ColorProvider, useColor } from './ColorContext'
+
+describe('ColorProvider', () => {
+  it('throws when useColor is used outside provider', () => {
+    const { result } = renderHook(() => {
+      try {
+        // Should throw
+        useColor()
+      } catch (e) {
+        return e
+      }
+    })
+    expect(result.current).toBeInstanceOf(Error)
+  })
+
+  it('updates css variables on setColor', () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <ColorProvider>{children}</ColorProvider>
+    )
+    const { result } = renderHook(() => useColor(), { wrapper })
+
+    act(() => {
+      result.current.setColor('#ff0000')
+    })
+
+    expect(document.documentElement.style.getPropertyValue('--hue-default')).toBe('0')
+    expect(document.documentElement.style.getPropertyValue('--saturation-default')).toBe('100%')
+    expect(document.documentElement.style.getPropertyValue('--lightness-default')).toBe('50%')
+    expect(document.documentElement.style.getPropertyValue('--text-color')).toBe('white')
+  })
+})

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import convertColor from './utils'
+
+describe('convertColor', () => {
+  it('converts hex to rgb and hsl', () => {
+    const result = convertColor('#ff0000')
+    expect(result.rgb).toBe('rgb(255, 0, 0)')
+    expect(result.hsl).toBe('hsl(0, 100%, 50%)')
+    expect(result.hex).toBe('#ff0000')
+    expect(result.rgbObj).toEqual({ r: 255, g: 0, b: 0 })
+    expect(result.hslObj).toEqual({ h: 0, s: 100, l: 50 })
+  })
+
+  it('converts rgb to hex and hsl', () => {
+    const result = convertColor('rgb(0, 128, 255)')
+    expect(result.hex).toBe('#0080ff')
+    expect(result.hsl).toBe('hsl(210, 100%, 50%)')
+    expect(result.rgb).toBe('rgb(0, 128, 255)')
+  })
+
+  it('converts hsl to hex and rgb', () => {
+    const result = convertColor('hsl(120, 100%, 50%)')
+    expect(result.hex).toBe('#00ff00')
+    expect(result.rgb).toBe('rgb(0, 255, 0)')
+    expect(result.hsl).toBe('hsl(120, 100%, 50%)')
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,12 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react-swc'
+import { configDefaults } from 'vitest/config'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    exclude: [...configDefaults.exclude, 'dist/**'],
+  },
 })


### PR DESCRIPTION
## Summary
- add Vitest configuration in `vite.config.ts`
- add test script and dev dependencies
- create unit tests for color conversion utilities
- create tests for ColorContext provider

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c7aa260c0832a9c18b9b6698ab944